### PR TITLE
Fix the hostname tablets use when self-registering.

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: vitess-operator
       containers:
         - name: vitess-operator
-          image: vitess/operator:v0.0.1
+          image: vitess/operator:v0.0.2
           ports:
           - containerPort: 60000
             name: metrics

--- a/pkg/util/scripts/tablet.go
+++ b/pkg/util/scripts/tablet.go
@@ -23,7 +23,7 @@ tablet_uid=$((16#${uid_hash:0:6} * 100 + $pod_index))
 echo $tablet_uid > /vtdataroot/tabletdata/tablet-uid
 
 # Tell MySQL what hostname to report in SHOW SLAVE HOSTS.
-echo report-host=$hostname.{{ .Cluster.Name }}-vttablet > /vtdataroot/tabletdata/report-host.cnf
+echo report-host=$hostname.{{ .Cluster.Name }}-tab > /vtdataroot/tabletdata/report-host.cnf
 
 # Orchestrator looks there, so it should match -tablet_hostname above.
 
@@ -80,7 +80,7 @@ eval exec /vt/bin/vttablet $(cat <<END_OF_COMMAND
   -service_map="grpc-queryservice,grpc-tabletmanager,grpc-updatestream"
   -tablet_dir="tabletdata"
   -tablet-path="{{ .Cell.Name }}-$(cat /vtdataroot/tabletdata/tablet-uid)"
-  -tablet_hostname="$(hostname).{{ .Cluster.Name }}-vttablet"
+  -tablet_hostname="$(hostname).{{ .Cluster.Name }}-tab"
   -init_keyspace="{{ .Keyspace.Name }}"
   -init_shard="{{ .Shard.Spec.KeyRange }}"
   -init_tablet_type="{{ .Tablet.Spec.Type }}"

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.0.1"
+	Version = "0.0.2"
 )


### PR DESCRIPTION
Previously, tablets were registering under NAME-vttablet, but the
headless service is actually just called "tab". So tablets were registering
with hostnames that were not reachable. This fixes #15.

Signed-off-by: Carson Anderson <ca@carsonoid.net>