### PR TITLE
fix #17: Endless loop at “init-replica-master” job

### DIFF
--- a/pkg/util/scripts/init_replica_master.go
+++ b/pkg/util/scripts/init_replica_master.go
@@ -43,7 +43,7 @@ until [ $TABLETS_READY ]; do
   tabletCount=$( echo "$shardTablets" | wc | awk '{print $1}')
 
   # check to see if the tablet count equals the expected tablet count
-  if [ $tabletCount == 2 ]; then
+  if [ $tabletCount == {{ .Shard.Spec.Defaults.Replicas }} ]; then
     TABLETS_READY=true
   else
     if (( $SECONDS > $TIMEOUT_SECONDS )); then


### PR DESCRIPTION
In this code, "tabletCount" is hard coded.
https://github.com/vitessio/vitess-operator/blob/master/pkg/util/scripts/init_replica_master.go#L46

So we need to modify from "2" to "{{ .Shard.Spec.Defaults.Replicas }}".
https://github.com/vitessio/vitess-operator/blob/fbad8683b217c7d773a8252d38538d6a9f4b52c5/pkg/util/scripts/main.go#L115
https://github.com/vitessio/vitess-operator/blob/master/pkg/apis/vitess/v1alpha2/vitessshard_types.go#L31