### PR TITLE
VitessCellMySQLProtocol.Username is invalid jsontag "image".

### DIFF
--- a/pkg/apis/vitess/v1alpha2/vitesscell_types.go
+++ b/pkg/apis/vitess/v1alpha2/vitesscell_types.go
@@ -44,7 +44,7 @@ type VitessCellDefaults struct {
 type VitessCellMySQLProtocol struct {
 	AuthType VitessMySQLAuthType `json:"authType,omitempty"`
 
-	Username string `json:"image,omitempty"`
+	Username string `json:"username,omitempty"`
 
 	// Password string `json:"password"`
 


### PR DESCRIPTION
VitessCellMySQLProtocol.Username is invalid jsontag "image".

```
type VitessCellDefaults struct {
	Replicas *int32 `json:"replicas"`

	Image string `json:"image"`
}

type VitessCellMySQLProtocol struct {
	AuthType VitessMySQLAuthType `json:"authType,omitempty"`

	Username string `json:"image,omitempty"`

	// Password string `json:"password"`

	PasswordSecretRef *corev1.SecretKeySelector `json:"passwordSecretRef,omitempty"`
}
```